### PR TITLE
feat: add ECS configs for Fargate Spot and Task Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ For detailed API documentation, please refer to the [API Reference](https://api.
 
 ### Setting Up Environment Variables
 
-Before making API calls, you need to set your hostname and API keys. Replace the placeholders with your actual Langfuse URL, Public Key, and Private Key.
+Before making API calls, you need to set your hostname and API keys. Replace the placeholders with your actual Langfuse URL, Public Key, and Secret Key.
 
 ```sh
-export LANGFUSE_HOST="YOUR_LANGFUSE_URL"
+export LANGFUSE_SECRET_KEY="YOUR_SECRET_KEY"
 export LANGFUSE_PUBLIC_KEY="YOUR_PUBLIC_KEY"
-export LANGFUSE_PRIVATE_KEY="YOUR_PRIVATE_KEY"
+export LANGFUSE_HOST="YOUR_LANGFUSE_URL"
 ```
 
 ### Performing a Health Check
@@ -78,7 +78,7 @@ You can perform a health check using the following curl command:
 
 ```sh
 curl "$LANGFUSE_HOST/api/public/health" \
-  --header "Authorization: $LANGFUSE_PUBLIC_KEY:$LANGFUSE_PRIVATE_KEY"
+  --header "Authorization: $LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY"
 ```
 
 #### Expected Result
@@ -98,7 +98,7 @@ This example demonstrates how to send a trace creation request.
 
 ```sh
 curl -X POST "$LANGFUSE_HOST/api/public/ingestion" \
-  -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_PRIVATE_KEY" \
+  -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "batch": [

--- a/lib/langfuse-with-aws-cdk-stack.ts
+++ b/lib/langfuse-with-aws-cdk-stack.ts
@@ -98,6 +98,9 @@ export class LangfuseWithAwsCdkStack extends cdk.Stack {
     const clickhouse = new ClickHouse(this, 'ClickHouse', {
       vpc,
       cluster,
+      enableFargateSpot: stackConfig.enableFargateSpot,
+      taskDefCpu: stackConfig.taskDefCpu,
+      taskDefMemoryLimitMiB: stackConfig.taskDefMemoryLimitMiB,
       imageTag: clickhouseImageTag,
     });
 
@@ -131,6 +134,10 @@ export class LangfuseWithAwsCdkStack extends cdk.Stack {
       allowedIPv4Cidrs,
       allowedIPv6Cidrs,
       cluster,
+      enableFargateSpot: stackConfig.enableFargateSpot,
+      taskDefCpu: stackConfig.taskDefCpu,
+      taskDefMemoryLimitMiB: stackConfig.taskDefMemoryLimitMiB,
+      langfuseWebTaskCount: stackConfig.langfuseWebTaskCount,
       imageTag: langfuseImageTag,
       logLevel: langfuseLogLvel,
       encryptionKey,
@@ -146,6 +153,9 @@ export class LangfuseWithAwsCdkStack extends cdk.Stack {
      */
     new Worker(this, 'Worker', {
       cluster,
+      enableFargateSpot: stackConfig.enableFargateSpot,
+      taskDefCpu: stackConfig.taskDefCpu,
+      taskDefMemoryLimitMiB: stackConfig.taskDefMemoryLimitMiB,
       imageTag: langfuseImageTag,
       logLevel: langfuseLogLvel,
       encryptionKey,

--- a/lib/stack-config.ts
+++ b/lib/stack-config.ts
@@ -14,6 +14,44 @@ export interface StackConfig {
   allowedIPv6Cidrs?: string[];
 
   /**
+   * Whether to use Fargate Spot for Langfuse web/server and ClickHouse.
+   *
+   * @default - Not use Fargate Spot
+   */
+  enableFargateSpot?: boolean;
+
+  /**
+   * The vCPU of Fargate Task Definition for Langfuse web/server and ClickHouse.
+   *
+   * Langfuse recommend that you should have at least 2 CPUs for production environments.
+   *
+   * @default 1024
+   * @see https://langfuse.com/self-hosting/infrastructure/containers#recommended-sizing
+   */
+  taskDefCpu?: number;
+
+  /**
+   * The amount (in MiN) of Memory of Fargate Task Definition for Langfuse web/server and ClickHouse.
+   *
+   * Langfuse recommend that you should have at 4 GB of RAM for production environments.
+   *
+   * @default 2048
+   * @see https://langfuse.com/self-hosting/infrastructure/containers#recommended-sizing
+   */
+  taskDefMemoryLimitMiB?: number;
+
+
+  /**
+   * The number of task for Langfuse Web.
+   *
+   * Langfuse recommend that you should have at least two containers for production environments.
+   *
+   * @default undefined - ECS default setting is 1
+   * @see https://langfuse.com/self-hosting/infrastructure/containers#recommended-sizing
+   */
+  langfuseWebTaskCount?: number;
+
+  /**
    * The Docker image tag for the Langfuse application.
    *
    * @default 'latest'
@@ -68,6 +106,7 @@ export enum LOG_LEVEL {
 
 const stackConfigMap: Record<string, StackConfig> = {
   dev: {
+    enableFargateSpot: true,
     createBastion: true,
     langfuseLogLevel: LOG_LEVEL.DEBUG,
     auroraScalesToZero: true,
@@ -79,6 +118,9 @@ const stackConfigMap: Record<string, StackConfig> = {
     cacheMultiAz: false,
   },
   prod: {
+    taskDefCpu: 2048,
+    taskDefMemoryLimitMiB: 4096,
+    langfuseWebTaskCount: 2,
     createBastion: true,
     langfuseLogLevel: LOG_LEVEL.INFO,
     langfuseImageTag: 'latest',

--- a/test/__snapshots__/langfuse-with-aws-cdk-dev.test.ts.snap
+++ b/test/__snapshots__/langfuse-with-aws-cdk-dev.test.ts.snap
@@ -113,7 +113,20 @@ exports[`snapshot test for prod 1`] = `
       "Export": {
         "Name": "LangfuseURL",
       },
-      "Value": "https://langfuse.example.com",
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "http://",
+            {
+              "Fn::GetAtt": [
+                "WebApplicationLoadBalancerCC36E523",
+                "DNSName",
+              ],
+            },
+          ],
+        ],
+      },
     },
   },
   "Parameters": {
@@ -807,6 +820,16 @@ exports[`snapshot test for prod 1`] = `
         "ClickHouseTaskDefinitionTaskRole41536CE9",
       ],
       "Properties": {
+        "CapacityProviderStrategy": [
+          {
+            "CapacityProvider": "FARGATE",
+            "Weight": 0,
+          },
+          {
+            "CapacityProvider": "FARGATE_SPOT",
+            "Weight": 1,
+          },
+        ],
         "Cluster": {
           "Ref": "ClusterEB0386A7",
         },
@@ -821,7 +844,6 @@ exports[`snapshot test for prod 1`] = `
         },
         "EnableECSManagedTags": false,
         "EnableExecuteCommand": true,
-        "LaunchType": "FARGATE",
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {
             "AssignPublicIp": "DISABLED",
@@ -1269,7 +1291,7 @@ exports[`snapshot test for prod 1`] = `
         "Port": 5432,
         "ServerlessV2ScalingConfiguration": {
           "MaxCapacity": 2,
-          "MinCapacity": 0.5,
+          "MinCapacity": 0,
         },
         "StorageEncrypted": true,
         "VpcSecurityGroupIds": [
@@ -1986,36 +2008,6 @@ exports[`snapshot test for prod 1`] = `
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "WebAliasRecord22320298": {
-      "Properties": {
-        "AliasTarget": {
-          "DNSName": {
-            "Fn::Join": [
-              "",
-              [
-                "dualstack.",
-                {
-                  "Fn::GetAtt": [
-                    "WebApplicationLoadBalancerCC36E523",
-                    "DNSName",
-                  ],
-                },
-              ],
-            ],
-          },
-          "HostedZoneId": {
-            "Fn::GetAtt": [
-              "WebApplicationLoadBalancerCC36E523",
-              "CanonicalHostedZoneID",
-            ],
-          },
-        },
-        "HostedZoneId": "DUMMY",
-        "Name": "langfuse.example.com.",
-        "Type": "A",
-      },
-      "Type": "AWS::Route53::RecordSet",
-    },
     "WebApplicationLoadBalancerCC36E523": {
       "DependsOn": [
         "VPCPublicSubnet1DefaultRoute91CEF279",
@@ -2068,13 +2060,6 @@ exports[`snapshot test for prod 1`] = `
     },
     "WebApplicationLoadBalancerListenerD48857F0": {
       "Properties": {
-        "Certificates": [
-          {
-            "CertificateArn": {
-              "Ref": "WebCertificateDA5CDDF6",
-            },
-          },
-        ],
         "DefaultActions": [
           {
             "TargetGroupArn": {
@@ -2086,8 +2071,8 @@ exports[`snapshot test for prod 1`] = `
         "LoadBalancerArn": {
           "Ref": "WebApplicationLoadBalancerCC36E523",
         },
-        "Port": 443,
-        "Protocol": "HTTPS",
+        "Port": 80,
+        "Protocol": "HTTP",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
@@ -2097,17 +2082,17 @@ exports[`snapshot test for prod 1`] = `
         "SecurityGroupIngress": [
           {
             "CidrIp": "0.0.0.0/0",
-            "Description": "from 0.0.0.0/0:443",
-            "FromPort": 443,
+            "Description": "from 0.0.0.0/0:80",
+            "FromPort": 80,
             "IpProtocol": "tcp",
-            "ToPort": 443,
+            "ToPort": 80,
           },
           {
             "CidrIpv6": "::/0",
-            "Description": "from ::/0:443",
-            "FromPort": 443,
+            "Description": "from ::/0:80",
+            "FromPort": 80,
             "IpProtocol": "tcp",
-            "ToPort": 443,
+            "ToPort": 80,
           },
         ],
         "VpcId": {
@@ -2137,25 +2122,6 @@ exports[`snapshot test for prod 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
-    "WebCertificateDA5CDDF6": {
-      "Properties": {
-        "DomainName": "langfuse.example.com",
-        "DomainValidationOptions": [
-          {
-            "DomainName": "langfuse.example.com",
-            "HostedZoneId": "DUMMY",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "MyTestStack/Web/Certificate",
-          },
-        ],
-        "ValidationMethod": "DNS",
-      },
-      "Type": "AWS::CertificateManager::Certificate",
-    },
     "WebNextAuthSecretB20A2FF1": {
       "DeletionPolicy": "Delete",
       "Properties": {
@@ -2174,6 +2140,16 @@ exports[`snapshot test for prod 1`] = `
         "WebTaskDefinitionTaskRole96791EDD",
       ],
       "Properties": {
+        "CapacityProviderStrategy": [
+          {
+            "CapacityProvider": "FARGATE",
+            "Weight": 0,
+          },
+          {
+            "CapacityProvider": "FARGATE_SPOT",
+            "Weight": 1,
+          },
+        ],
         "Cluster": {
           "Ref": "ClusterEB0386A7",
         },
@@ -2189,7 +2165,6 @@ exports[`snapshot test for prod 1`] = `
         "EnableECSManagedTags": false,
         "EnableExecuteCommand": true,
         "HealthCheckGracePeriodSeconds": 60,
-        "LaunchType": "FARGATE",
         "LoadBalancers": [
           {
             "ContainerName": "Container",
@@ -2333,7 +2308,20 @@ exports[`snapshot test for prod 1`] = `
             "Environment": [
               {
                 "Name": "NEXTAUTH_URL",
-                "Value": "https://langfuse.example.com",
+                "Value": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "http://",
+                      {
+                        "Fn::GetAtt": [
+                          "WebApplicationLoadBalancerCC36E523",
+                          "DNSName",
+                        ],
+                      },
+                    ],
+                  ],
+                },
               },
               {
                 "Name": "TELEMETRY_ENABLED",
@@ -2349,7 +2337,7 @@ exports[`snapshot test for prod 1`] = `
               },
               {
                 "Name": "LANGFUSE_LOG_LEVEL",
-                "Value": "info",
+                "Value": "debug",
               },
               {
                 "Name": "DATABASE_NAME",
@@ -2742,6 +2730,16 @@ exports[`snapshot test for prod 1`] = `
         "WorkerTaskDefinitionTaskRoleDCDA51F5",
       ],
       "Properties": {
+        "CapacityProviderStrategy": [
+          {
+            "CapacityProvider": "FARGATE",
+            "Weight": 0,
+          },
+          {
+            "CapacityProvider": "FARGATE_SPOT",
+            "Weight": 1,
+          },
+        ],
         "Cluster": {
           "Ref": "ClusterEB0386A7",
         },
@@ -2756,7 +2754,6 @@ exports[`snapshot test for prod 1`] = `
         },
         "EnableECSManagedTags": false,
         "EnableExecuteCommand": true,
-        "LaunchType": "FARGATE",
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {
             "AssignPublicIp": "DISABLED",
@@ -2842,7 +2839,7 @@ exports[`snapshot test for prod 1`] = `
               },
               {
                 "Name": "LANGFUSE_LOG_LEVEL",
-                "Value": "info",
+                "Value": "debug",
               },
               {
                 "Name": "DATABASE_NAME",

--- a/test/__snapshots__/langfuse-with-aws-cdk-prod.test.ts.snap
+++ b/test/__snapshots__/langfuse-with-aws-cdk-prod.test.ts.snap
@@ -959,7 +959,7 @@ exports[`snapshot test for prod 1`] = `
             ],
           },
         ],
-        "Cpu": "1024",
+        "Cpu": "2048",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "ClickHouseTaskDefinitionExecutionRole0586239A",
@@ -967,7 +967,7 @@ exports[`snapshot test for prod 1`] = `
           ],
         },
         "Family": "MyTestStackClickHouseTaskDefinition3CB4B9B6",
-        "Memory": "2048",
+        "Memory": "4096",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",
@@ -2186,6 +2186,7 @@ exports[`snapshot test for prod 1`] = `
           "MaximumPercent": 200,
           "MinimumHealthyPercent": 50,
         },
+        "DesiredCount": 2,
         "EnableECSManagedTags": false,
         "EnableExecuteCommand": true,
         "HealthCheckGracePeriodSeconds": 60,
@@ -2498,7 +2499,7 @@ exports[`snapshot test for prod 1`] = `
             ],
           },
         ],
-        "Cpu": "1024",
+        "Cpu": "2048",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "WebTaskDefinitionExecutionRole9B66D88D",
@@ -2506,7 +2507,7 @@ exports[`snapshot test for prod 1`] = `
           ],
         },
         "Family": "MyTestStackWebTaskDefinition8428B33B",
-        "Memory": "2048",
+        "Memory": "4096",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",
@@ -2985,7 +2986,7 @@ exports[`snapshot test for prod 1`] = `
             ],
           },
         ],
-        "Cpu": "1024",
+        "Cpu": "2048",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "WorkerTaskDefinitionExecutionRole04BD42F4",
@@ -2993,7 +2994,7 @@ exports[`snapshot test for prod 1`] = `
           ],
         },
         "Family": "MyTestStackWorkerTaskDefinition957E58DF",
-        "Memory": "2048",
+        "Memory": "4096",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/test/__snapshots__/langfuse-with-aws-cdk-stg.test.ts.snap
+++ b/test/__snapshots__/langfuse-with-aws-cdk-stg.test.ts.snap
@@ -113,7 +113,20 @@ exports[`snapshot test for prod 1`] = `
       "Export": {
         "Name": "LangfuseURL",
       },
-      "Value": "https://langfuse.example.com",
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "http://",
+            {
+              "Fn::GetAtt": [
+                "WebApplicationLoadBalancerCC36E523",
+                "DNSName",
+              ],
+            },
+          ],
+        ],
+      },
     },
   },
   "Parameters": {
@@ -1269,7 +1282,7 @@ exports[`snapshot test for prod 1`] = `
         "Port": 5432,
         "ServerlessV2ScalingConfiguration": {
           "MaxCapacity": 2,
-          "MinCapacity": 0.5,
+          "MinCapacity": 0,
         },
         "StorageEncrypted": true,
         "VpcSecurityGroupIds": [
@@ -1986,36 +1999,6 @@ exports[`snapshot test for prod 1`] = `
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "WebAliasRecord22320298": {
-      "Properties": {
-        "AliasTarget": {
-          "DNSName": {
-            "Fn::Join": [
-              "",
-              [
-                "dualstack.",
-                {
-                  "Fn::GetAtt": [
-                    "WebApplicationLoadBalancerCC36E523",
-                    "DNSName",
-                  ],
-                },
-              ],
-            ],
-          },
-          "HostedZoneId": {
-            "Fn::GetAtt": [
-              "WebApplicationLoadBalancerCC36E523",
-              "CanonicalHostedZoneID",
-            ],
-          },
-        },
-        "HostedZoneId": "DUMMY",
-        "Name": "langfuse.example.com.",
-        "Type": "A",
-      },
-      "Type": "AWS::Route53::RecordSet",
-    },
     "WebApplicationLoadBalancerCC36E523": {
       "DependsOn": [
         "VPCPublicSubnet1DefaultRoute91CEF279",
@@ -2068,13 +2051,6 @@ exports[`snapshot test for prod 1`] = `
     },
     "WebApplicationLoadBalancerListenerD48857F0": {
       "Properties": {
-        "Certificates": [
-          {
-            "CertificateArn": {
-              "Ref": "WebCertificateDA5CDDF6",
-            },
-          },
-        ],
         "DefaultActions": [
           {
             "TargetGroupArn": {
@@ -2086,8 +2062,8 @@ exports[`snapshot test for prod 1`] = `
         "LoadBalancerArn": {
           "Ref": "WebApplicationLoadBalancerCC36E523",
         },
-        "Port": 443,
-        "Protocol": "HTTPS",
+        "Port": 80,
+        "Protocol": "HTTP",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
@@ -2097,17 +2073,17 @@ exports[`snapshot test for prod 1`] = `
         "SecurityGroupIngress": [
           {
             "CidrIp": "0.0.0.0/0",
-            "Description": "from 0.0.0.0/0:443",
-            "FromPort": 443,
+            "Description": "from 0.0.0.0/0:80",
+            "FromPort": 80,
             "IpProtocol": "tcp",
-            "ToPort": 443,
+            "ToPort": 80,
           },
           {
             "CidrIpv6": "::/0",
-            "Description": "from ::/0:443",
-            "FromPort": 443,
+            "Description": "from ::/0:80",
+            "FromPort": 80,
             "IpProtocol": "tcp",
-            "ToPort": 443,
+            "ToPort": 80,
           },
         ],
         "VpcId": {
@@ -2136,25 +2112,6 @@ exports[`snapshot test for prod 1`] = `
         "ToPort": 3000,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
-    },
-    "WebCertificateDA5CDDF6": {
-      "Properties": {
-        "DomainName": "langfuse.example.com",
-        "DomainValidationOptions": [
-          {
-            "DomainName": "langfuse.example.com",
-            "HostedZoneId": "DUMMY",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "MyTestStack/Web/Certificate",
-          },
-        ],
-        "ValidationMethod": "DNS",
-      },
-      "Type": "AWS::CertificateManager::Certificate",
     },
     "WebNextAuthSecretB20A2FF1": {
       "DeletionPolicy": "Delete",
@@ -2333,7 +2290,20 @@ exports[`snapshot test for prod 1`] = `
             "Environment": [
               {
                 "Name": "NEXTAUTH_URL",
-                "Value": "https://langfuse.example.com",
+                "Value": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "http://",
+                      {
+                        "Fn::GetAtt": [
+                          "WebApplicationLoadBalancerCC36E523",
+                          "DNSName",
+                        ],
+                      },
+                    ],
+                  ],
+                },
               },
               {
                 "Name": "TELEMETRY_ENABLED",

--- a/test/langfuse-with-aws-cdk-dev.test.ts
+++ b/test/langfuse-with-aws-cdk-dev.test.ts
@@ -4,7 +4,7 @@ import * as LangfuseWithAwsCdk from '../lib/langfuse-with-aws-cdk-stack';
 import { getAppConfig } from '../bin/app-config';
 
 test('snapshot test for prod', () => {
-  const envName = 'prod';
+  const envName = 'dev';
 
   const app = new cdk.App();
 

--- a/test/langfuse-with-aws-cdk-stg.test.ts
+++ b/test/langfuse-with-aws-cdk-stg.test.ts
@@ -4,7 +4,7 @@ import * as LangfuseWithAwsCdk from '../lib/langfuse-with-aws-cdk-stack';
 import { getAppConfig } from '../bin/app-config';
 
 test('snapshot test for prod', () => {
-  const envName = 'prod';
+  const envName = 'stg';
 
   const app = new cdk.App();
 


### PR DESCRIPTION
Add ECS Configuration Options:
* Configure Fargate Spot usage
* Configure CPU and memory settings for Fargate task definitions
* Set task count for Langfuse web service