### PR TITLE
fix: containerPath in mountPoints is wrong

### DIFF
--- a/lib/constructs/services/clickhouse.ts
+++ b/lib/constructs/services/clickhouse.ts
@@ -107,7 +107,7 @@ export class ClickHouse extends Construct implements ec2.IConnectable {
 
     container.addMountPoints({
       sourceVolume: 'clickhouse',
-      containerPath: '/clickhouse',
+      containerPath: '/var/lib/clickhouse',
       readOnly: false,
     });
 

--- a/test/__snapshots__/langfuse-with-aws-cdk-dev.test.ts.snap
+++ b/test/__snapshots__/langfuse-with-aws-cdk-dev.test.ts.snap
@@ -950,7 +950,7 @@ exports[`snapshot test for dev 1`] = `
             },
             "MountPoints": [
               {
-                "ContainerPath": "/clickhouse",
+                "ContainerPath": "/var/lib/clickhouse",
                 "ReadOnly": false,
                 "SourceVolume": "clickhouse",
               },

--- a/test/__snapshots__/langfuse-with-aws-cdk-prod.test.ts.snap
+++ b/test/__snapshots__/langfuse-with-aws-cdk-prod.test.ts.snap
@@ -928,7 +928,7 @@ exports[`snapshot test for prod 1`] = `
             },
             "MountPoints": [
               {
-                "ContainerPath": "/clickhouse",
+                "ContainerPath": "/var/lib/clickhouse",
                 "ReadOnly": false,
                 "SourceVolume": "clickhouse",
               },

--- a/test/__snapshots__/langfuse-with-aws-cdk-stg.test.ts.snap
+++ b/test/__snapshots__/langfuse-with-aws-cdk-stg.test.ts.snap
@@ -941,7 +941,7 @@ exports[`snapshot test for stg 1`] = `
             },
             "MountPoints": [
               {
-                "ContainerPath": "/clickhouse",
+                "ContainerPath": "/var/lib/clickhouse",
                 "ReadOnly": false,
                 "SourceVolume": "clickhouse",
               },


### PR DESCRIPTION
The mount point path for EFS in my open source ClickHouse Fargate task was incorrect, preventing data from being persisted to EFS. 
So I need to fix the mount point path to resolve this issue.