### PR TITLE
refactor: Extract common environment variables in Langfuse web/worker into a separate file

### DIFF
--- a/lib/constructs/services/common-environment.ts
+++ b/lib/constructs/services/common-environment.ts
@@ -1,0 +1,81 @@
+import { Construct } from 'constructs';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { Database } from '../database';
+import { Cache } from '../cache';
+import { ClickHouse } from './clickhouse';
+import { LOG_LEVEL } from '../../stack-config';
+
+export interface CommonEnvironmentProps {
+  logLevel: LOG_LEVEL;
+  database: Database;
+  cache: Cache;
+  clickhouse: ClickHouse;
+  bucket: s3.IBucket;
+}
+
+export class CommonEnvironment extends Construct {
+  public readonly commonEnvironment: { [key: string]: string };
+  public readonly commonSecrets: { [key: string]: ecs.Secret };
+  constructor(scope: Construct, id: string, props: CommonEnvironmentProps) {
+    super(scope, id);
+
+    const { logLevel, database, cache, clickhouse, bucket } = props;
+
+    /**
+     * Encryption Key and Salt for Langfuse Services
+     */
+    const encryptionKey = new secretsmanager.Secret(this, 'EncryptionKey', {
+      generateSecretString: {
+        passwordLength: 64,
+        excludeCharacters: 'ghijklmnopqrstuvwxyzGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+=-[]{};:,.<>?/', // only 0-9, a-f used
+        excludePunctuation: true,
+        excludeUppercase: true,
+        requireEachIncludedType: false,
+      },
+    });
+
+    const salt = new secretsmanager.Secret(this, 'Salt', {
+      generateSecretString: {
+        passwordLength: 32,
+        excludePunctuation: true,
+      },
+    });
+
+    /**
+     * Common environment variables and secrest for Langfuse Web/Worker
+     * @see https://langfuse.com/self-hosting/configuration
+     */
+    this.commonEnvironment = {
+      TELEMETRY_ENABLED: 'true',
+      LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: 'true',
+      LANGFUSE_LOG_LEVEL: logLevel,
+
+      DATABASE_NAME: database.databaseName,
+
+      CLICKHOUSE_MIGRATION_URL: 'clickhouse://clickhouse-tcp.local:9000',
+      CLICKHOUSE_URL: 'http://clickhouse-http.local:8123',
+      CLICKHOUSE_USER: clickhouse.clickhouseUser,
+      CLICKHOUSE_CLUSTER_ENABLED: 'false',
+
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: bucket.bucketName,
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: 'events/',
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: bucket.bucketName,
+      LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: 'media/',
+    };
+
+    this.commonSecrets = {
+      SALT: ecs.Secret.fromSecretsManager(salt),
+      ENCRYPTION_KEY: ecs.Secret.fromSecretsManager(encryptionKey),
+
+      DATABASE_HOST: ecs.Secret.fromSecretsManager(database.secret, 'host'),
+      DATABASE_USERNAME: ecs.Secret.fromSecretsManager(database.secret, 'username'),
+      DATABASE_PASSWORD: ecs.Secret.fromSecretsManager(database.secret, 'password'),
+
+      REDIS_CONNECTION_STRING: ecs.Secret.fromSecretsManager(cache.connectionStringSecret),
+
+      CLICKHOUSE_PASSWORD: ecs.Secret.fromSecretsManager(clickhouse.clickhousePassword),
+    };
+  }
+}

--- a/lib/stack-config.ts
+++ b/lib/stack-config.ts
@@ -130,7 +130,7 @@ const stackConfigMap: Record<string, StackConfig> = {
     langfuseWebTaskCount: 2,
     createBastion: true,
     langfuseLogLevel: LOG_LEVEL.INFO,
-    langfuseImageTag: 'latest',
+    langfuseImageTag: '3.26',
     auroraScalesToZero: false,
     cacheMultiAz: false,
   },

--- a/test/__snapshots__/langfuse-with-aws-cdk-dev.test.ts.snap
+++ b/test/__snapshots__/langfuse-with-aws-cdk-dev.test.ts.snap
@@ -1194,6 +1194,31 @@ exports[`snapshot test for dev 1`] = `
       },
       "Type": "AWS::ECS::Cluster",
     },
+    "CommonEnvironmentEncryptionKeyEEEB3C1C": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {
+          "ExcludeCharacters": "ghijklmnopqrstuvwxyzGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+=-[]{};:,.<>?/",
+          "ExcludePunctuation": true,
+          "ExcludeUppercase": true,
+          "PasswordLength": 64,
+          "RequireEachIncludedType": false,
+        },
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "CommonEnvironmentSalt326EB889": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {
+          "ExcludePunctuation": true,
+          "PasswordLength": 32,
+        },
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
     "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": {
       "DependsOn": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
@@ -1464,31 +1489,6 @@ exports[`snapshot test for dev 1`] = `
         },
       },
       "Type": "AWS::RDS::DBClusterParameterGroup",
-    },
-    "EncryptionKey1B843E66": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "GenerateSecretString": {
-          "ExcludeCharacters": "ghijklmnopqrstuvwxyzGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+=-[]{};:,.<>?/",
-          "ExcludePunctuation": true,
-          "ExcludeUppercase": true,
-          "PasswordLength": 64,
-          "RequireEachIncludedType": false,
-        },
-      },
-      "Type": "AWS::SecretsManager::Secret",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "SaltDBAE3CEC": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "GenerateSecretString": {
-          "ExcludePunctuation": true,
-          "PasswordLength": 32,
-        },
-      },
-      "Type": "AWS::SecretsManager::Secret",
-      "UpdateReplacePolicy": "Delete",
     },
     "VPCB9E5F0B4": {
       "Properties": {
@@ -2367,16 +2367,16 @@ sudo service iptables save",
                 },
               },
               {
+                "Name": "HOSTNAME",
+                "Value": "0.0.0.0",
+              },
+              {
                 "Name": "TELEMETRY_ENABLED",
                 "Value": "true",
               },
               {
                 "Name": "LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES",
                 "Value": "true",
-              },
-              {
-                "Name": "HOSTNAME",
-                "Value": "0.0.0.0",
               },
               {
                 "Name": "LANGFUSE_LOG_LEVEL",
@@ -2463,13 +2463,13 @@ sudo service iptables save",
               {
                 "Name": "SALT",
                 "ValueFrom": {
-                  "Ref": "SaltDBAE3CEC",
+                  "Ref": "CommonEnvironmentSalt326EB889",
                 },
               },
               {
                 "Name": "ENCRYPTION_KEY",
                 "ValueFrom": {
-                  "Ref": "EncryptionKey1B843E66",
+                  "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
                 },
               },
               {
@@ -2605,7 +2605,7 @@ sudo service iptables save",
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SaltDBAE3CEC",
+                "Ref": "CommonEnvironmentSalt326EB889",
               },
             },
             {
@@ -2615,7 +2615,7 @@ sudo service iptables save",
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "EncryptionKey1B843E66",
+                "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
               },
             },
             {
@@ -2959,13 +2959,13 @@ sudo service iptables save",
               {
                 "Name": "SALT",
                 "ValueFrom": {
-                  "Ref": "SaltDBAE3CEC",
+                  "Ref": "CommonEnvironmentSalt326EB889",
                 },
               },
               {
                 "Name": "ENCRYPTION_KEY",
                 "ValueFrom": {
-                  "Ref": "EncryptionKey1B843E66",
+                  "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
                 },
               },
               {
@@ -3096,7 +3096,7 @@ sudo service iptables save",
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SaltDBAE3CEC",
+                "Ref": "CommonEnvironmentSalt326EB889",
               },
             },
             {
@@ -3106,7 +3106,7 @@ sudo service iptables save",
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "EncryptionKey1B843E66",
+                "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
               },
             },
             {

--- a/test/__snapshots__/langfuse-with-aws-cdk-prod.test.ts.snap
+++ b/test/__snapshots__/langfuse-with-aws-cdk-prod.test.ts.snap
@@ -1172,6 +1172,31 @@ exports[`snapshot test for prod 1`] = `
       },
       "Type": "AWS::ECS::Cluster",
     },
+    "CommonEnvironmentEncryptionKeyEEEB3C1C": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {
+          "ExcludeCharacters": "ghijklmnopqrstuvwxyzGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+=-[]{};:,.<>?/",
+          "ExcludePunctuation": true,
+          "ExcludeUppercase": true,
+          "PasswordLength": 64,
+          "RequireEachIncludedType": false,
+        },
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "CommonEnvironmentSalt326EB889": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {
+          "ExcludePunctuation": true,
+          "PasswordLength": 32,
+        },
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
     "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": {
       "DependsOn": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
@@ -1442,31 +1467,6 @@ exports[`snapshot test for prod 1`] = `
         },
       },
       "Type": "AWS::RDS::DBClusterParameterGroup",
-    },
-    "EncryptionKey1B843E66": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "GenerateSecretString": {
-          "ExcludeCharacters": "ghijklmnopqrstuvwxyzGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+=-[]{};:,.<>?/",
-          "ExcludePunctuation": true,
-          "ExcludeUppercase": true,
-          "PasswordLength": 64,
-          "RequireEachIncludedType": false,
-        },
-      },
-      "Type": "AWS::SecretsManager::Secret",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "SaltDBAE3CEC": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "GenerateSecretString": {
-          "ExcludePunctuation": true,
-          "PasswordLength": 32,
-        },
-      },
-      "Type": "AWS::SecretsManager::Secret",
-      "UpdateReplacePolicy": "Delete",
     },
     "VPCB9E5F0B4": {
       "Properties": {
@@ -2337,16 +2337,16 @@ exports[`snapshot test for prod 1`] = `
                 "Value": "https://langfuse.example.com",
               },
               {
+                "Name": "HOSTNAME",
+                "Value": "0.0.0.0",
+              },
+              {
                 "Name": "TELEMETRY_ENABLED",
                 "Value": "true",
               },
               {
                 "Name": "LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES",
                 "Value": "true",
-              },
-              {
-                "Name": "HOSTNAME",
-                "Value": "0.0.0.0",
               },
               {
                 "Name": "LANGFUSE_LOG_LEVEL",
@@ -2404,7 +2404,7 @@ exports[`snapshot test for prod 1`] = `
               "StartPeriod": 30,
               "Timeout": 5,
             },
-            "Image": "langfuse/langfuse:latest",
+            "Image": "langfuse/langfuse:3.26",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -2433,13 +2433,13 @@ exports[`snapshot test for prod 1`] = `
               {
                 "Name": "SALT",
                 "ValueFrom": {
-                  "Ref": "SaltDBAE3CEC",
+                  "Ref": "CommonEnvironmentSalt326EB889",
                 },
               },
               {
                 "Name": "ENCRYPTION_KEY",
                 "ValueFrom": {
-                  "Ref": "EncryptionKey1B843E66",
+                  "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
                 },
               },
               {
@@ -2575,7 +2575,7 @@ exports[`snapshot test for prod 1`] = `
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SaltDBAE3CEC",
+                "Ref": "CommonEnvironmentSalt326EB889",
               },
             },
             {
@@ -2585,7 +2585,7 @@ exports[`snapshot test for prod 1`] = `
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "EncryptionKey1B843E66",
+                "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
               },
             },
             {
@@ -2897,7 +2897,7 @@ exports[`snapshot test for prod 1`] = `
               "StartPeriod": 30,
               "Timeout": 5,
             },
-            "Image": "langfuse/langfuse-worker:latest",
+            "Image": "langfuse/langfuse-worker:3.26",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -2920,13 +2920,13 @@ exports[`snapshot test for prod 1`] = `
               {
                 "Name": "SALT",
                 "ValueFrom": {
-                  "Ref": "SaltDBAE3CEC",
+                  "Ref": "CommonEnvironmentSalt326EB889",
                 },
               },
               {
                 "Name": "ENCRYPTION_KEY",
                 "ValueFrom": {
-                  "Ref": "EncryptionKey1B843E66",
+                  "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
                 },
               },
               {
@@ -3057,7 +3057,7 @@ exports[`snapshot test for prod 1`] = `
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SaltDBAE3CEC",
+                "Ref": "CommonEnvironmentSalt326EB889",
               },
             },
             {
@@ -3067,7 +3067,7 @@ exports[`snapshot test for prod 1`] = `
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "EncryptionKey1B843E66",
+                "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
               },
             },
             {

--- a/test/__snapshots__/langfuse-with-aws-cdk-stg.test.ts.snap
+++ b/test/__snapshots__/langfuse-with-aws-cdk-stg.test.ts.snap
@@ -1185,6 +1185,31 @@ exports[`snapshot test for stg 1`] = `
       },
       "Type": "AWS::ECS::Cluster",
     },
+    "CommonEnvironmentEncryptionKeyEEEB3C1C": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {
+          "ExcludeCharacters": "ghijklmnopqrstuvwxyzGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+=-[]{};:,.<>?/",
+          "ExcludePunctuation": true,
+          "ExcludeUppercase": true,
+          "PasswordLength": 64,
+          "RequireEachIncludedType": false,
+        },
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "CommonEnvironmentSalt326EB889": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {
+          "ExcludePunctuation": true,
+          "PasswordLength": 32,
+        },
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
     "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": {
       "DependsOn": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
@@ -1455,31 +1480,6 @@ exports[`snapshot test for stg 1`] = `
         },
       },
       "Type": "AWS::RDS::DBClusterParameterGroup",
-    },
-    "EncryptionKey1B843E66": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "GenerateSecretString": {
-          "ExcludeCharacters": "ghijklmnopqrstuvwxyzGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+=-[]{};:,.<>?/",
-          "ExcludePunctuation": true,
-          "ExcludeUppercase": true,
-          "PasswordLength": 64,
-          "RequireEachIncludedType": false,
-        },
-      },
-      "Type": "AWS::SecretsManager::Secret",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "SaltDBAE3CEC": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "GenerateSecretString": {
-          "ExcludePunctuation": true,
-          "PasswordLength": 32,
-        },
-      },
-      "Type": "AWS::SecretsManager::Secret",
-      "UpdateReplacePolicy": "Delete",
     },
     "VPCB9E5F0B4": {
       "Properties": {
@@ -2306,16 +2306,16 @@ exports[`snapshot test for stg 1`] = `
                 },
               },
               {
+                "Name": "HOSTNAME",
+                "Value": "0.0.0.0",
+              },
+              {
                 "Name": "TELEMETRY_ENABLED",
                 "Value": "true",
               },
               {
                 "Name": "LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES",
                 "Value": "true",
-              },
-              {
-                "Name": "HOSTNAME",
-                "Value": "0.0.0.0",
               },
               {
                 "Name": "LANGFUSE_LOG_LEVEL",
@@ -2402,13 +2402,13 @@ exports[`snapshot test for stg 1`] = `
               {
                 "Name": "SALT",
                 "ValueFrom": {
-                  "Ref": "SaltDBAE3CEC",
+                  "Ref": "CommonEnvironmentSalt326EB889",
                 },
               },
               {
                 "Name": "ENCRYPTION_KEY",
                 "ValueFrom": {
-                  "Ref": "EncryptionKey1B843E66",
+                  "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
                 },
               },
               {
@@ -2544,7 +2544,7 @@ exports[`snapshot test for stg 1`] = `
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SaltDBAE3CEC",
+                "Ref": "CommonEnvironmentSalt326EB889",
               },
             },
             {
@@ -2554,7 +2554,7 @@ exports[`snapshot test for stg 1`] = `
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "EncryptionKey1B843E66",
+                "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
               },
             },
             {
@@ -2889,13 +2889,13 @@ exports[`snapshot test for stg 1`] = `
               {
                 "Name": "SALT",
                 "ValueFrom": {
-                  "Ref": "SaltDBAE3CEC",
+                  "Ref": "CommonEnvironmentSalt326EB889",
                 },
               },
               {
                 "Name": "ENCRYPTION_KEY",
                 "ValueFrom": {
-                  "Ref": "EncryptionKey1B843E66",
+                  "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
                 },
               },
               {
@@ -3026,7 +3026,7 @@ exports[`snapshot test for stg 1`] = `
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SaltDBAE3CEC",
+                "Ref": "CommonEnvironmentSalt326EB889",
               },
             },
             {
@@ -3036,7 +3036,7 @@ exports[`snapshot test for stg 1`] = `
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "EncryptionKey1B843E66",
+                "Ref": "CommonEnvironmentEncryptionKeyEEEB3C1C",
               },
             },
             {


### PR DESCRIPTION
closes #7 

Many environment variables and secrets are shared between Langfuse web and worker.
To improve maintainability, these common environment variables and secrets have been extracted into a separate file.