### PR TITLE
fix: frequent Idle timeout errors

### DIFF
--- a/lib/constructs/database.ts
+++ b/lib/constructs/database.ts
@@ -37,13 +37,15 @@ export class Database extends Construct implements ec2.IConnectable {
       enableDataApi: true,
       storageEncrypted: true,
       removalPolicy: RemovalPolicy.DESTROY,
-      parameterGroup: new rds.ParameterGroup(this, 'ParameterGroup', {
-        engine,
-        parameters: {
-          // Terminate idle session for Aurora Serverless V2 auto-pause
-          idle_session_timeout: '60000',
-        },
-      }),
+      parameterGroup: auroraScalesToZero
+        ? // Terminate idle session for Aurora Serverless V2 auto-pause
+          new rds.ParameterGroup(this, 'ParameterGroup', {
+            engine,
+            parameters: {
+              idle_session_timeout: '60000',
+            },
+          })
+        : undefined,
     });
 
     this.connections = cluster.connections;

--- a/test/__snapshots__/langfuse-with-aws-cdk-prod.test.ts.snap
+++ b/test/__snapshots__/langfuse-with-aws-cdk-prod.test.ts.snap
@@ -1574,9 +1574,7 @@ exports[`snapshot test for prod 1`] = `
       "DeletionPolicy": "Delete",
       "Properties": {
         "CopyTagsToSnapshot": true,
-        "DBClusterParameterGroupName": {
-          "Ref": "DatabaseParameterGroup2A921026",
-        },
+        "DBClusterParameterGroupName": "default.aurora-postgresql16",
         "DBSubnetGroupName": {
           "Ref": "DatabaseClusterSubnets5540150D",
         },
@@ -1774,16 +1772,6 @@ exports[`snapshot test for prod 1`] = `
       },
       "Type": "AWS::RDS::DBInstance",
       "UpdateReplacePolicy": "Delete",
-    },
-    "DatabaseParameterGroup2A921026": {
-      "Properties": {
-        "Description": "Cluster parameter group for aurora-postgresql16",
-        "Family": "aurora-postgresql16",
-        "Parameters": {
-          "idle_session_timeout": "60000",
-        },
-      },
-      "Type": "AWS::RDS::DBClusterParameterGroup",
     },
     "LoadBalancerAlbAccessLogBucket57C7E043": {
       "DeletionPolicy": "Delete",


### PR DESCRIPTION
The idle timeout was configured to utilize Aurora Serverless v2's auto sleep feature, but this resulted in frequent idle timeouts and numerous error log outputs.

```sh
2025-02-16T14:00:05.489Z error prisma:error Error in PostgreSQL connection: Error { kind: Db, cause: Some(DbError { severity: "FATAL", parsed_severity: Some(Fatal), code: SqlState(E57P05), message: "terminating connection due to idle-session timeout", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("postgres.c"), line: Some(3681), routine: Some("ProcessInterrupts") }) }
```

While this is acceptable when auto sleep is enabled for cost optimization, it should be avoided when auto sleep is not in use.
Therefore, when auto sleep is disabled, we will modify the system to not create parameter groups that set idle timeout values.